### PR TITLE
Adapt to rename of DocParser in CommonMark

### DIFF
--- a/recommonmark/parser.py
+++ b/recommonmark/parser.py
@@ -3,7 +3,7 @@ import itertools
 
 from docutils import parsers, nodes
 
-from CommonMark import DocParser, HTMLRenderer
+from CommonMark import Parser, HTMLRenderer
 from warnings import warn
 
 __all__ = ['CommonMarkParser']
@@ -80,7 +80,7 @@ class CommonMarkParser(parsers.Parser):
         self.current_node = document
         self.section_handler = _SectionHandler(document)
 
-        parser = DocParser()
+        parser = Parser()
 
         ast = parser.parse(inputstring + '\n')
 


### PR DESCRIPTION
https://github.com/rtfd/CommonMark-py/commit/280ec2cb0582cf4ed6da159b6d150557bd5a97f1 broke recommonmark