### PR TITLE
CommonMark 0.6.0 compatibility

### DIFF
--- a/recommonmark/parser.py
+++ b/recommonmark/parser.py
@@ -3,7 +3,7 @@ import itertools
 
 from docutils import parsers, nodes
 
-from CommonMark import DocParser, HTMLRenderer
+from CommonMark import Parser, HtmlRenderer
 from warnings import warn
 
 __all__ = ['CommonMarkParser']
@@ -80,7 +80,7 @@ class CommonMarkParser(parsers.Parser):
         self.current_node = document
         self.section_handler = _SectionHandler(document)
 
-        parser = DocParser()
+        parser = Parser()
 
         ast = parser.parse(inputstring + '\n')
 
@@ -220,7 +220,7 @@ def inline_html(inline):
 
 
 def inline_entity(inline):
-    val = HTMLRenderer().renderInline(inline)
+    val = HtmlRenderer().renderInline(inline)
     entity_node = nodes.paragraph('', val, format='html')
     return entity_node
 


### PR DESCRIPTION
Update to [CommonMark 0.6.0](https://github.com/rtfd/CommonMark-py/releases/tag/0.6.0) changes to make it compatible:

* HTMLRenderer has been renamed to HtmlRenderer.

* DocParser has been renamed to Parser.