### PR TITLE
README.md: Link to the new CommonMark-py repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ It was originally created by [Luca Barbato][lu-zero],
 and is now maintained in the Read the Docs (rtfd) GitHub organization.
 
 [cm]: http://commonmark.org
-[pcm]: https://github.com/rolandshoemaker/CommonMark-py
+[pcm]: https://github.com/rtfd/CommonMark-py
 [rmd]: https://github.com/sgenoud/remarkdown
 [prs]: https://github.com/python-parsley/parsley
 [lu-zero]: https://github.com/lu-zero


### PR DESCRIPTION
The currently mentioned repo is abandoned and links to the new one.