### PR TITLE
Improve rst_eval

### DIFF
--- a/docs/auto_structify.md
+++ b/docs/auto_structify.md
@@ -123,9 +123,7 @@ E = m c^2
 
 ### Embed reStructuredText
 Recommonmark also allows embedding reStructuredText syntax in the codeblocks.
-This is enabled by ```eval_rst``` codeblock. The content of codeblock will be parsed as reStructuredText
-and insert into the document. This can be used to quickly introduce some of reStructuredText command that
-not yet available in markdown. For example,
+There are two styles for embedding reStructuredText. The first is enabled by ```eval_rst``` codeblock. The content of codeblock will be parsed as reStructuredText and insert into the document. This can be used to quickly introduce some of reStructuredText command that not yet available in markdown. For example,
 ```
 `` `eval_rst
 .. automodule:: recommonmark.parser.Parser
@@ -138,6 +136,78 @@ will be rendered as
     :show-inheritance:
 ```
 This example used to use sphinx autodoc to insert document of AutoStructify class definition into the document.
+
+The second style is a shorthand of the above style. It allows you to leave off the eval_rst .. portion and directly render directives. For example,
+
+```rst
+`` ` important:: Its a note! in markdown!
+`` `
+```
+will be rendered as
+
+``` important:: Its a note! in markdown!
+```
+
+#### An Advanced Example
+
+```rst
+
+`` ` sidebar:: Line numbers and highlights
+
+     emphasis-lines:
+       highlights the lines.
+     linenos:
+       shows the line numbers as well.
+     caption:
+       shown at the top of the code block.
+     name:
+       may be referenced with `:ref:` later.
+`` `
+
+`` ` code-block:: markdown
+     :linenos:
+     :emphasize-lines: 3,5
+     :caption: An example code-block with everything turned on.
+     :name: Full code-block example
+
+     # Comment line
+     import System
+     System.run_emphasis_line
+     # Long lines in code blocks create a auto horizontal scrollbar
+     System.exit!
+`` `
+```
+
+will be rendered as
+
+``` sidebar:: Line numbers and highlights
+
+    emphasis-lines:
+      highlights the lines.
+    linenos:
+      shows the line numbers as well.
+    caption:
+      shown at the top of the code block.
+    name:
+      may be referenced with `:ref:` later.
+```
+
+``` code-block:: markdown
+    :linenos:
+    :emphasize-lines: 3,5
+    :caption: An example code-block with everything turned on.
+    :name: Full code-block example
+
+    # Comment line
+    import System
+    System.run_emphasis_line
+    # Long lines in code blocks create a auto horizontal scrollbar
+    System.exit!
+```
+
+The `<div style="clear: right;"></div>` line clears the sidebar for the next title.
+
+<div style="clear: right;"></div>
 
 
 Inline Math

--- a/recommonmark/transform.py
+++ b/recommonmark/transform.py
@@ -1,9 +1,12 @@
 """Implement some common transforms on parsed AST."""
 import os
 import sys
+import re
 from .states import DummyStateMachine
 from docutils import nodes, transforms
 from docutils.statemachine import StringList
+from docutils.parsers.rst import Parser
+from docutils.utils import new_document
 
 
 class AutoStructify(transforms.Transform):
@@ -241,9 +244,18 @@ class AutoStructify(transforms.Transform):
                     0, node=node, match_titles=False)
                 return node.children[:]
         else:
-            return self.state_machine.run_directive(
-                'code-block', arguments=[language],
-                content=content)
+            directive_re = '[ ]?[\w_-]+::.*'
+            match = re.search(directive_re, language)
+            if match:
+                parser = Parser()
+                new_doc = new_document(None, self.document.settings)
+                newsource = u'.. ' + match.group(0) + '\n' + node.rawsource
+                parser.parse(newsource, new_doc)
+                return new_doc.children[:]
+            else:
+                return self.state_machine.run_directive(
+                    'code-block', arguments=[language],
+                    content=content)
         return None
 
     def find_replace(self, node):

--- a/recommonmark/transform.py
+++ b/recommonmark/transform.py
@@ -244,8 +244,7 @@ class AutoStructify(transforms.Transform):
                     0, node=node, match_titles=False)
                 return node.children[:]
         else:
-            directive_re = '[ ]?[\w_-]+::.*'
-            match = re.search(directive_re, language)
+            match = re.search('[ ]?[\w_-]+::.*', language)
             if match:
                 parser = Parser()
                 new_doc = new_document(None, self.document.settings)


### PR DESCRIPTION
I ran into an issue with using the `sidebar` directive with the ```eval_rst fenced blocks. This PR creates a shorthand syntax for rendered rst directives.

    ``` sidebar:: Sidebar title
        :caption: A caption

        The sidebar content
    ```

The detects the presence of double colons and renders them as directives rather than code-blocks. It also parses the directive nodes in a new document which fixes the rendering of sidebars. I am not sure if any other directives than sidebar that were previously broken and are now fixed.

Includes updated documentation for this as well:

![screen shot 2016-03-09 at 6 51 04 am](https://cloud.githubusercontent.com/assets/283496/13634537/27e49fae-e5c4-11e5-959f-ec94232b4d55.png)
 