### PR TITLE
Added path separator handler for non-Unix environment.

### DIFF
--- a/recommonmark/transform.py
+++ b/recommonmark/transform.py
@@ -65,10 +65,9 @@ class AutoStructify(transforms.Transform):
         abspath = os.path.abspath(os.path.join(self.file_dir, uri))
         relpath = os.path.relpath(abspath, self.root_dir)
         suffix = abspath.rsplit('.', 1)
-        
         if len(suffix) == 2 and suffix[1] in AutoStructify.suffix_set and (
                 os.path.exists(abspath) and abspath.startswith(self.root_dir)):
-            # replace the path separator if running on non-UNIX environment 
+            # replace the path separator if running on non-UNIX environment
             if os.path.sep != '/':
                 relpath = relpath.replace(os.path.sep, '/')
             docpath = '/' + relpath.rsplit('.', 1)[0]

--- a/recommonmark/transform.py
+++ b/recommonmark/transform.py
@@ -65,8 +65,12 @@ class AutoStructify(transforms.Transform):
         abspath = os.path.abspath(os.path.join(self.file_dir, uri))
         relpath = os.path.relpath(abspath, self.root_dir)
         suffix = abspath.rsplit('.', 1)
+        
         if len(suffix) == 2 and suffix[1] in AutoStructify.suffix_set and (
                 os.path.exists(abspath) and abspath.startswith(self.root_dir)):
+            # replace the path separator if running on non-UNIX environment 
+            if os.path.sep != '/':
+                relpath = relpath.replace(os.path.sep, '/')
             docpath = '/' + relpath.rsplit('.', 1)[0]
             # rewrite suffix to html, this is suboptimal
             uri = docpath + '.html'


### PR DESCRIPTION
This PR fixes issue #39.

**History**
I've been working on a project where I had to build docs with `Sphinx` and `markdown`.
The TOC wasn't building on `Windows` but was on `Linux`.
So this lead me to conclude it was an environment issue.
Upon debugging `Sphinx` I found that it was comparing the `found_docs` with the `docname` and in Windows the path didn't match due to the path separator.
Debugging `recommonmark` I found that in `tranform.py` `parse_ref` the `relpath` follows environment specs but `Sphinx` awaits the `relpath` to be in `Unix` format.

**About**
The submitted code fixes this issue. It's been tested on `Windows` and `Linux`.
Personally, I'm fairly new with `Python`, so if you happen to know a better way to resolve this issue, feel free to reject this PR, but please fix this for the next release as people developing on `Windows` will struggle to help me on the project without the TOC.