### PR TITLE
Turn package into a Sphinx extension

### DIFF
--- a/recommonmark/__init__.py
+++ b/recommonmark/__init__.py
@@ -1,1 +1,8 @@
 __version__ = '0.4.0'
+
+
+def setup(app):
+    """Initialize Sphinx extension."""
+    from .parser import CommonMarkParser
+    app.add_source_parser('.md', CommonMarkParser)  # needs Sphinx >= 1.4
+    return {'version': __version__, 'parallel_read_safe': True}


### PR DESCRIPTION
This way, it can be simply enabled like this (in `conf.py`):

```python
extensions = ['recommonmark']
```

Note, however, that this only works for Sphinx version >= 1.4 because it uses [add_source_parser()](http://www.sphinx-doc.org/en/stable/extdev/appapi.html#sphinx.application.Sphinx.add_source_parser).