### PR TITLE
Transform files with other endings besides .md

### DIFF
--- a/recommonmark/parser.py
+++ b/recommonmark/parser.py
@@ -114,7 +114,7 @@ class CommonMarkParser(parsers.Parser):
         self.current_node = new_section
 
     def verbatim(self, text):
-        verbatim_node = nodes.literal_block(text)
+        verbatim_node = nodes.literal_block()
         text = ''.join(flatten(text))
         if text.endswith('\n'):
             text = text[:-1]

--- a/recommonmark/parser.py
+++ b/recommonmark/parser.py
@@ -237,7 +237,6 @@ def reference(block):
         ref_node['refuri'] = block.destination
     else:
         ref_node['refname'] = label
-        # self.document.note_refname(ref_node)
 
     if block.title:
         ref_node['title'] = block.title

--- a/recommonmark/transform.py
+++ b/recommonmark/transform.py
@@ -26,6 +26,7 @@ class AutoStructify(transforms.Transform):
         'enable_eval_rst': True,
         'enable_math': True,
         'enable_inline_math': True,
+        'commonmark_suffixes': ['.md'],
         'url_resolver': lambda x: x,
     }
 
@@ -313,10 +314,7 @@ class AutoStructify(transforms.Transform):
 
     def apply(self):
         """Apply the transformation by configuration."""
-        # only transform markdowns
         source = self.document['source']
-        if not source.endswith('.md'):
-            return
 
         self.reporter = self.document.reporter
         self.reporter.info('AutoStructify: %s' % source)
@@ -328,6 +326,11 @@ class AutoStructify(transforms.Transform):
         except:
             self.reporter.warning('recommonmark_config not setted,'
                                   ' proceed default setting')
+
+        # only transform markdowns
+        if not source.endswith(tuple(config['commonmark_suffixes'])):
+            return
+
         self.url_resolver = config['url_resolver']
         assert callable(self.url_resolver)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 commonmark<=0.5.4
 docutils>=0.11
-sphinx==1.3.1
+sphinx>=1.3.1
 pytest==2.7.2

--- a/tests/sphinx_code_block/conf.py
+++ b/tests/sphinx_code_block/conf.py
@@ -1,0 +1,22 @@
+
+# -*- coding: utf-8 -*-
+
+from recommonmark.parser import CommonMarkParser
+
+templates_path = ['_templates']
+source_suffix = '.md'
+source_parsers = { '.md': CommonMarkParser }
+master_doc = 'index'
+project = u'sphinxproj'
+copyright = u'2015, rtfd'
+author = u'rtfd'
+version = '0.1'
+release = '0.1'
+highlight_language = 'python'
+language = None
+exclude_patterns = ['_build']
+pygments_style = 'sphinx'
+todo_include_todos = False
+html_theme = 'alabaster'
+html_static_path = ['_static']
+htmlhelp_basename = 'sphinxproj'

--- a/tests/sphinx_code_block/index.md
+++ b/tests/sphinx_code_block/index.md
@@ -1,0 +1,11 @@
+Header
+======
+
+A paragraph
+```
+def f():
+    pass
+```
+Another paragraph
+
+

--- a/tests/sphinx_custom_md/conf.py
+++ b/tests/sphinx_custom_md/conf.py
@@ -1,0 +1,30 @@
+
+# -*- coding: utf-8 -*-
+
+from recommonmark.parser import CommonMarkParser
+from recommonmark.transform import AutoStructify
+
+templates_path = ['_templates']
+source_suffix = '.markdown'
+source_parsers = { '.markdown': CommonMarkParser }
+master_doc = 'index'
+project = u'sphinxproj'
+copyright = u'2015, rtfd'
+author = u'rtfd'
+version = '0.1'
+release = '0.1'
+language = None
+exclude_patterns = ['_build']
+highlight_language = 'python'
+pygments_style = 'sphinx'
+todo_include_todos = False
+html_theme = 'alabaster'
+html_static_path = ['_static']
+htmlhelp_basename = 'sphinxproj'
+
+def setup(app):
+    app.add_config_value('recommonmark_config', {
+            'enable_eval_rst': True,
+            'commonmark_suffixes': ['.markdown', '.hpp'],
+            }, True)
+    app.add_transform(AutoStructify)

--- a/tests/sphinx_custom_md/index.markdown
+++ b/tests/sphinx_custom_md/index.markdown
@@ -1,0 +1,15 @@
+Header
+======
+
+A paragraph
+
+```eval_rst
++-----+------+
+| abc | data |
++=====+======+
+| a   | 1    |
++-----+------+
+```
+
+Another paragraph
+

--- a/tests/sphinx_indented_code/conf.py
+++ b/tests/sphinx_indented_code/conf.py
@@ -1,0 +1,22 @@
+
+# -*- coding: utf-8 -*-
+
+from recommonmark.parser import CommonMarkParser
+
+templates_path = ['_templates']
+source_suffix = '.md'
+source_parsers = { '.md': CommonMarkParser }
+master_doc = 'index'
+project = u'sphinxproj'
+copyright = u'2015, rtfd'
+author = u'rtfd'
+version = '0.1'
+release = '0.1'
+language = None
+exclude_patterns = ['_build']
+highlight_language = 'python'
+pygments_style = 'sphinx'
+todo_include_todos = False
+html_theme = 'alabaster'
+html_static_path = ['_static']
+htmlhelp_basename = 'sphinxproj'

--- a/tests/sphinx_indented_code/index.md
+++ b/tests/sphinx_indented_code/index.md
@@ -1,0 +1,10 @@
+Header
+======
+
+A paragraph
+
+    def f():
+        pass
+
+Another paragraph
+

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -1,0 +1,48 @@
+import os
+import io
+import sys
+import shutil
+import unittest
+
+from sphinx.application import Sphinx
+
+
+class SphinxIntegrationTests(unittest.TestCase):
+
+    def _run_test(self, test_dir, test_file, test_string):
+        os.chdir('tests/{0}'.format(test_dir))
+        try:
+            app = Sphinx(
+                srcdir='.',
+                confdir='.',
+                outdir='_build/text',
+                doctreedir='_build/.doctrees',
+                buildername='html',
+                verbosity=1,
+            )
+            app.build(force_all=True)
+            with io.open(test_file, encoding='utf-8') as fin:
+                text = fin.read().strip()
+                self.assertIn(test_string, text)
+        finally:
+            shutil.rmtree('_build')
+            os.chdir('../..')
+
+class CodeBlockTests(SphinxIntegrationTests):
+
+    def test_integration(self):
+        self._run_test(
+            'sphinx_code_block',
+            '_build/text/index.html',
+            '<div class="highlight">'
+        )
+
+
+class IndentedCodeTests(SphinxIntegrationTests):
+
+    def test_integration(self):
+        self._run_test(
+            'sphinx_indented_code',
+            '_build/text/index.html',
+            '<div class="highlight">'
+        )

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -46,3 +46,12 @@ class IndentedCodeTests(SphinxIntegrationTests):
             '_build/text/index.html',
             '<div class="highlight">'
         )
+
+class CustomExtensionTests(SphinxIntegrationTests):
+
+    def test_integration(self):
+        self._run_test(
+            'sphinx_custom_md',
+            '_build/text/index.html',
+            '</table>'
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,9 @@ commands =
     py.test {posargs}
 
 [testenv:docs]
-deps = {[testenv]deps}
+deps = 
+    {[testenv]deps}
+    sphinx_rtd_theme
 changedir = {toxinidir}/docs
 commands =
     sphinx-build -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html


### PR DESCRIPTION
This adds a configuration variable `commonmark_suffixes` where the user can specify which files with which extensions the AutoStructify transform will apply to. This is because I have markdown files that have endings other than '.md'.