### PR TITLE
Fix eval_rst so it assigns source properly

### DIFF
--- a/recommonmark/transform.py
+++ b/recommonmark/transform.py
@@ -228,6 +228,7 @@ class AutoStructify(transforms.Transform):
             The converted toc tree node, None if conversion is not possible.
         """
         assert isinstance(node, nodes.literal_block)
+        original_node = node
         if 'language' not in node:
             return None
         self.state_machine.reset(self.document,
@@ -244,7 +245,7 @@ class AutoStructify(transforms.Transform):
                 # allow embed non section level rst
                 node = nodes.section()
                 self.state_machine.state.nested_parse(
-                    StringList(content, source=node.rawsource),
+                    StringList(content, source=original_node.source),
                     0, node=node, match_titles=False)
                 return node.children[:]
         else:


### PR DESCRIPTION
At the moment it is passing source as node.rawsource.  This is always
going to be the empty string as it is getting it from a newly created
node.

This patch saves a reference to the original node and parses down the
correct source.  This patch along with #52 means that eval_rst blocks will
internationalize correctly fixing [#47].  Sphinx will not translate
nodes with a blank source.

Also relative paths will now work within eval_rst blocks.