### PR TITLE
Add support for CommonMark 0.7.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-commonmark<=0.5.4
+commonmark>=0.6.0
 docutils>=0.11
 sphinx>=1.3.1
 pytest==2.7.2

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -9,7 +9,6 @@ class TestStringMethods(unittest.TestCase):
 
     def test_basic_parser(self):
         source = '# Header'
-
         ret = publish_parts(
             source=source,
             writer_name='html',


### PR DESCRIPTION
This updates recommonmark to use CommonMark version 0.6.x and 0.7.x

Only the test named `CustomExtensionTests.test_integration` fails. Can this be linked to (from the [changelog of CommonMark](https://github.com/rtfd/CommonMark-py/blob/master/CHANGELOG.md#060-2016-01-04)):

> The ExtensionBlock has been removed in this release, since the parser has been rewritten.

I think we should add more tests: some methods (eg `blockquote`) are not tested and are likely to be broken with the new CommonMark parser. I should be able to do that within next week.

Feedback appreciated!

Fix #24 