### PR TITLE
Update README links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Documentation is available on Read the Docs: <http://recommonmark.readthedocs.or
 
 Contents
 --------
-* [API Reference](api_ref.md)
-* [AutoStructify Component](auto_structify.md)
+* [API Reference](docs/api_ref.md)
+* [AutoStructify Component](docs/auto_structify.md)
 
 ## Getting Started
 


### PR DESCRIPTION
Links in `README.md` did not consider the `docs/` folder. These changes should fix the problem.