### PR TITLE
Add support for basic markdown tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ AutoStructify comes with the following options. See http://recommonmark.readthed
 * __enable_math__: enable the Math Formula feature.
 * __enable_inline_math__: enable the Inline Math feature.
 * __enable_eval_rst__: enable the evaluate embedded reStructuredText feature.
+* __enable_table_extension__: enable basic markdown table support.
 * __url_resolver__: a function that maps a existing relative position in the document to a http link
 
 ## Development

--- a/docs/auto_structify.md
+++ b/docs/auto_structify.md
@@ -21,16 +21,16 @@ def setup(app):
     app.add_transform(AutoStructify)
 
 ```
-All the features are by default enabled
 
 ***List of options***
-* __enable_auto_toc_tree__: whether enable [Auto Toc Tree](#auto-toc-tree) feature.
-* __auto_toc_tree_section__: when enabled,  [Auto Toc Tree](#auto-toc-tree) will only be enabled on section that matches the title.
-* __enable_auto_doc_ref__: whether enable [Auto Doc Ref](#auto-doc-ref) feature.
-* __enable_math__: whether enable [Math Formula](#math-formula)
-* __enable_inline_math__: whether enable [Inline Math](#inline-math)
-* __enable_eval_rst__: whether [Embed reStructuredText](#embed-restructuredtext) is enabled.
-* __url_resolver__: a function that maps a existing relative position in the document to a http link
+* __enable_auto_toc_tree__: whether enable [Auto Toc Tree](#auto-toc-tree) feature. (enabled by default)
+* __auto_toc_tree_section__: when enabled,  [Auto Toc Tree](#auto-toc-tree) will only be enabled on section that matches the title. (enabled by default)
+* __enable_auto_doc_ref__: whether enable [Auto Doc Ref](#auto-doc-ref) feature. (enabled by default)
+* __enable_math__: whether enable [Math Formula](#math-formula) (enabled by default)
+* __enable_inline_math__: whether enable [Inline Math](#inline-math) (enabled by default)
+* __enable_eval_rst__: whether [Embed reStructuredText](#embed-restructuredtext) is enabled. (enabled by default)
+* __enable_table_extension__: enable basic markdown table support. (disabled by default)
+* __url_resolver__: a function that maps a existing relative position in the document to a http link (enabled by default)
 
 Auto Toc Tree
 -------------
@@ -235,3 +235,31 @@ This formula `$ y=\sum_{i=1}^n g(x_i) $`
 will be rendered as:
 
 This formula `$ y=\sum_{i=1}^n g(x_i) $`
+
+Table Extension
+---------------
+The table extension brings basic support for markdown tables. Currently only text and references (links) are supported
+to be used within cells.
+
+The table must comply with following syntax:
+```
+Example:
+| abc | data |
+|-----|------|
+| a   | 1    |
+
+Headers are not required:
+| abc | data |
+| a   | 1    |
+
+Cells do not need to align:
+| abc | data |
+| a | 1 |
+```
+
+Tables which use github flavoured syntax are __not supported__:
+```
+ abc | data
+-----|------
+ a   | 1
+```

--- a/tests/sphinx_table_extension/conf.py
+++ b/tests/sphinx_table_extension/conf.py
@@ -1,0 +1,30 @@
+
+# -*- coding: utf-8 -*-
+
+from recommonmark.parser import CommonMarkParser
+from recommonmark.transform import AutoStructify
+
+templates_path = ['_templates']
+source_suffix = '.markdown'
+source_parsers = { '.markdown': CommonMarkParser }
+master_doc = 'index'
+project = u'sphinxproj'
+copyright = u'2015, rtfd'
+author = u'rtfd'
+version = '0.1'
+release = '0.1'
+language = None
+exclude_patterns = ['_build']
+highlight_language = 'python'
+pygments_style = 'sphinx'
+todo_include_todos = False
+html_theme = 'alabaster'
+html_static_path = ['_static']
+htmlhelp_basename = 'sphinxproj'
+
+def setup(app):
+    app.add_config_value('recommonmark_config', {
+            'enable_table_extension': True,
+            'commonmark_suffixes': ['.markdown', '.hpp'],
+            }, True)
+    app.add_transform(AutoStructify)

--- a/tests/sphinx_table_extension/index.markdown
+++ b/tests/sphinx_table_extension/index.markdown
@@ -1,0 +1,12 @@
+| abc | data |
+|-----|------|
+| a   | 1    |
+
+# My link collection
+
+| What | Website |
+| Online Encyclopedia   | [wikipedia.org](https://www.wikipedia.org/)    |
+| Programming Language  | [python.org](https://www.python.org/) |
+| Social Media | [twitter](https://twitter.com/), [facebook](https://www.facebook.com/) |
+
+Another paragraph

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -74,3 +74,13 @@ class XrefTests(SphinxIntegrationTests):
             '_build/text/index.html',
             ['href="link.html"', 'href="http://www.google.com"']
         )
+
+class TableExtensionTests(SphinxIntegrationTests):
+
+    def test_integration(self):
+        self._run_test(
+            'sphinx_table_extension',
+            '_build/text/index.html',
+            ['</table>', 'href="https://www.wikipedia.org/"', 'href="https://www.python.org/"',
+             'href="https://twitter.com/"', 'href="https://www.facebook.com/"']
+        )


### PR DESCRIPTION
Add optional (default disabled) option to allow basic markdown tables.
The method added will convert the markdown table to a reStructuredText table on the fly
and passes it to docutils to create a node.

Please provide feedback for my suggested solution.