### PR TITLE
Fix auto doc ref feature to work with file extensions

### DIFF
--- a/recommonmark/transform.py
+++ b/recommonmark/transform.py
@@ -46,13 +46,13 @@ class AutoStructify(transforms.Transform):
             docpath is the absolute document path to the document, if
             the target corresponds to an internal document, this can bex None
         """
-        assert isinstance(ref, nodes.reference)
+        assert (isinstance(ref, nodes.reference) or isinstance(ref, sphinx.addnodes.pending_xref))
         title = None
         if len(ref.children) == 0:
             title = ref['name']
         elif isinstance(ref.children[0], nodes.Text):
             title = ref.children[0].astext()
-        uri = ref['refuri']
+        uri = ref['refuri'] if isinstance(ref, nodes.reference) else ref['reftarget']
         if uri.find('://') != -1:
             return (title, uri, None)
         anchor = None
@@ -170,7 +170,6 @@ class AutoStructify(transforms.Transform):
         """
         if not self.config['enable_auto_doc_ref']:
             return None
-        assert isinstance(node, nodes.reference)
         title, uri, docpath = self.parse_ref(node)
         if title is None:
             return None
@@ -279,7 +278,7 @@ class AutoStructify(transforms.Transform):
         newnode = None
         if isinstance(node, nodes.Sequential):
             newnode = self.auto_toc_tree(node)
-        elif isinstance(node, nodes.reference):
+        elif isinstance(node, nodes.reference) or isinstance(node, sphinx.addnodes.pending_xref):
             newnode = self.auto_doc_ref(node)
         elif isinstance(node, nodes.literal_block):
             newnode = self.auto_code_block(node)

--- a/tests/sphinx_xref/conf.py
+++ b/tests/sphinx_xref/conf.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from recommonmark.parser import CommonMarkParser
+from recommonmark.transform import AutoStructify
 
 templates_path = ['_templates']
 source_suffix = '.md'
@@ -20,3 +21,7 @@ todo_include_todos = False
 html_theme = 'alabaster'
 html_static_path = ['_static']
 htmlhelp_basename = 'sphinxproj'
+
+
+def setup(app):
+    app.add_transform(AutoStructify)

--- a/tests/sphinx_xref/index.md
+++ b/tests/sphinx_xref/index.md
@@ -1,5 +1,6 @@
 Header
 ======
 
-A paragraph [link](link) and [absolute link](/link). An [external link](http://www.google.com).
+A paragraph [link](link), an [absolute link](/link) and a [link with file extension](link.md).
+An [external link](http://www.google.com).
 


### PR DESCRIPTION
To enable links with file extension (e.g. link.md) it is required to also
pass nodes of the pending_xref type to the according python function.