### PR TITLE
Fix contents directive and auto_doc_ref

### DIFF
--- a/recommonmark/parser.py
+++ b/recommonmark/parser.py
@@ -233,7 +233,7 @@ def inline_entity(inline):
 
 
 def make_refnode(label, target, has_explicit_title):
-    if target and target.startswith(('http://', 'https://')):
+    if target and target.startswith(('http://', 'https://', 'mailto:')):
         ref_node = nodes.reference()
         ref_node['name'] = label
         ref_node['refuri'] = target

--- a/recommonmark/transform.py
+++ b/recommonmark/transform.py
@@ -246,7 +246,7 @@ class AutoStructify(transforms.Transform):
                 node = nodes.section()
                 self.state_machine.state.nested_parse(
                     StringList(content, source=original_node.source),
-                    0, node=node, match_titles=False)
+                    0, node=node, match_titles=True)
                 return node.children[:]
         else:
             match = re.search('[ ]?[\w_-]+::.*', language)

--- a/recommonmark/transform.py
+++ b/recommonmark/transform.py
@@ -161,8 +161,8 @@ class AutoStructify(transforms.Transform):
         added by .parser.make_refnode instead of normal references."""
         ref_node = nodes.reference()
         try:
-            ref_node['name'] = node.source
-            ref_node['refuri'] = node["reftarget"]
+            ref_node.children = node.children
+            ref_node['refuri'] = node['reftarget']
             return self.auto_doc_ref(ref_node)
         except (AttributeError, KeyError):
             return None


### PR DESCRIPTION
The `.. contents::` directive will error if `match_titles=False` in parsing. This sets `match_titles=True`, resolving #45.

Also fixes `auto_doc_ref`, which wasn't working because the `parser` was replacing all `nodes.reference` objects that didn't point to URLs with `sphinx.addnodes.pending_xref` objects instead.