### PR TITLE
Bump version to 0.4.1

### DIFF
--- a/recommonmark/__init__.py
+++ b/recommonmark/__init__.py
@@ -1,6 +1,6 @@
 """Docutils CommonMark parser"""
 
-__version__ = '0.4.0'
+__version__ = '0.4.1'
 
 
 def setup(app):


### PR DESCRIPTION
This allows pulling a recommonmark version into readthedocs that works
with new commonmark versions (> 0.5.4) using requirements.txt.

Closes: https://github.com/rtfd/recommonmark/issues/38#issuecomment-303637300