### PR TITLE
Fix hard error on cross-linking markdown document

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -183,7 +183,7 @@ class TestParsing(unittest.TestCase):
             <?xml version="1.0" ?>
             <document source="&lt;string&gt;">
               <paragraph>
-                <pending_xref refexplicit="True" reftarget="/foo" reftype="any" refwarn="True">
+                <pending_xref refdomain="None" refexplicit="True" reftarget="/foo" reftype="any" refwarn="True">
                   <reference refuri="/foo">link</reference>
                 </pending_xref>
               </paragraph>
@@ -198,7 +198,7 @@ class TestParsing(unittest.TestCase):
             <?xml version="1.0" ?>
             <document source="&lt;string&gt;">
               <paragraph>
-                <pending_xref refexplicit="True" reftarget="foo" reftype="any" refwarn="True">
+                <pending_xref refdomain="None" refexplicit="True" reftarget="foo" reftype="any" refwarn="True">
                   <reference refuri="foo">link</reference>
                 </pending_xref>
               </paragraph>
@@ -274,21 +274,21 @@ class TestParsing(unittest.TestCase):
               <bullet_list>
                 <list_item>
                   <paragraph>
-                    <pending_xref refexplicit="True" reftarget="/1" reftype="any" refwarn="True">
+                    <pending_xref refdomain="None" refexplicit="True" reftarget="/1" reftype="any" refwarn="True">
                       <reference refuri="/1">List item 1</reference>
                     </pending_xref>
                   </paragraph>
                 </list_item>
                 <list_item>
                   <paragraph>
-                    <pending_xref refexplicit="True" reftarget="/2" reftype="any" refwarn="True">
+                    <pending_xref refdomain="None" refexplicit="True" reftarget="/2" reftype="any" refwarn="True">
                       <reference refuri="/2">List item 2</reference>
                     </pending_xref>
                   </paragraph>
                 </list_item>
                 <list_item>
                   <paragraph>
-                    <pending_xref refexplicit="True" reftarget="/3" reftype="any" refwarn="True">
+                    <pending_xref refdomain="None" refexplicit="True" reftarget="/3" reftype="any" refwarn="True">
                       <reference refuri="/3">List item 3</reference>
                     </pending_xref>
                   </paragraph>


### PR DESCRIPTION
Sphinx 1.6.5 with tip recommonmark hard errors when a markdown document contains a cross-reference to another local markdown document as it unconditionally access the `refdomain` of a `pending_xref`. This was fixed [elsewhere](https://github.com/ignatenkobrain/sphinxcontrib-issuetracker/pull/13/files#diff-61beda6e59ec3020dbf0c2826dbb64c4R161) by setting it to `None`. This patch uses the same approach which no longer causes the Sphinx build to fail on cross-linking a markdown document however the generated link is not correctly rendered producing broken links in the generated html.

Addressing the broken links, the `mdnode.destination` is stripped of its file extension if that extension is supported by `CommonMarkParser` however this will only work for markdown documents, not ReStructuedText or any other extended file type parsers.

Fixes #89.