### PR TITLE
Updating autostructify links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ For all links in commonmark that aren't explicit URLs, they are treated as cross
 
 ### AutoStructify
 
+AutoStructify makes it possible to write your documentation in Markdown, and automatically convert this
+into rST at build time. See [the AutoStructify Documentation](http://recommonmark.readthedocs.org/en/latest/auto_structify.html)
+for more information about configuration and usage.
+
 To use the advanced markdown to rst transformations you must add `AutoStructify` to your Sphinx conf.py.
 
 ```python
@@ -59,7 +63,7 @@ def setup(app):
 
 See https://github.com/rtfd/recommonmark/blob/master/docs/conf.py for a full example.
 
-AutoStructify comes with the following options. See http://recommonmark.readthedocs.org/en/latest/auto_structify.html for more information about the specific features.
+AutoStructify comes with the following options. See [http://recommonmark.readthedocs.org/en/latest/auto_structify.html](http://recommonmark.readthedocs.org/en/latest/auto_structify.html) for more information about the specific features.
 
 * __enable_auto_toc_tree__: enable the Auto Toc Tree feature.
 * __auto_toc_tree_section__: when True, Auto Toc Tree will only be enabled on section that matches the title.


### PR DESCRIPTION
The links are hard to find, so this makes them more discoverable. On the RTD site, the autostructify link doesn't show as a clickable link, making it really hard to find:

![image](https://user-images.githubusercontent.com/1839645/36064338-5af1190a-0e3e-11e8-9d5f-3a4754049f40.png)

This makes that link a proper link so it shows up in the page, and adds a short paragraph at the beginning of the section mentioning the existence of the autostructify docs