### PR TITLE
Add section name translate support

### DIFF
--- a/recommonmark/parser.py
+++ b/recommonmark/parser.py
@@ -23,6 +23,7 @@ class CommonMarkParser(parsers.Parser):
     """Docutils parser for CommonMark"""
 
     supported = ('md', 'markdown')
+    translate_section_name = None
 
     def __init__(self):
         self._level_to_elem = {}
@@ -93,7 +94,10 @@ class CommonMarkParser(parsers.Parser):
         assert isinstance(self.current_node, nodes.title)
         # The title node has a tree of text nodes, use the whole thing to
         # determine the section id and names
-        name = nodes.fully_normalize_name(self.current_node.astext())
+        text = self.current_node.astext()
+        if self.translate_section_name:
+            text = self.translate_section_name(text)
+        name = nodes.fully_normalize_name(text)
         section = self.current_node.parent
         section['names'].append(name)
         self.document.note_implicit_target(section, section)


### PR DESCRIPTION
When section name is not written in ASCII, the ID of the section will be
generated by default, in the form of 'id<unique number>'. This is no good
writing links to other document, whose ID are subject to change in adding
or removing sections.

Adding a `translate_section_name` filter in Parser will allow user to install
a customized one to translate the section name into more readable one. For
example, convert the Chinese section name to more ASCII-friendly pinyin.