### PR TITLE
Add more metadata to setup.py for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,14 @@ import recommonmark
 setup(
     name='recommonmark',
     version=recommonmark.__version__,
+    description=('A docutils-compatibility bridge to CommonMark, '
+                 'enabling you to write CommonMark '
+                 'inside of Docutils & Sphinx projects.'),
+    url='https://github.com/rtfd/recommonmark',
+    license='MIT',
+    classifiers=[
+        'License :: OSI Approved :: MIT License',
+    ],
     install_requires=[
         'commonmark>=0.7.3',
         'docutils>=0.11',


### PR DESCRIPTION
Add a description, URL and license to `setup.py` so [the recommonmark package page on PyPI](https://pypi.org/project/recommonmark/) will include that information.