### PR TITLE
Register a parser class using new Sphinx API; add_source_suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ pip install recommonmark
 Then add this to your Sphinx conf.py:
 
 ```
+# for Sphinx-1.4 or newer
+extensions = ['recommonmark']
+
+# for Sphinx-1.3
 from recommonmark.parser import CommonMarkParser
 
 source_parsers = {

--- a/recommonmark/__init__.py
+++ b/recommonmark/__init__.py
@@ -5,6 +5,13 @@ __version__ = '0.4.0'
 
 def setup(app):
     """Initialize Sphinx extension."""
+    import sphinx
     from .parser import CommonMarkParser
-    app.add_source_parser('.md', CommonMarkParser)  # needs Sphinx >= 1.4
+
+    if sphinx.version_info >= (1, 8):
+        app.add_source_suffix('.md', 'markdown')
+        app.add_source_parser(CommonMarkParser)
+    elif sphinx.version_info >= (1, 4):
+        app.add_source_parser('.md', CommonMarkParser)
+
     return {'version': __version__, 'parallel_read_safe': True}


### PR DESCRIPTION
Hello developers,

Since Sphinx-1.8, it will provide a new API called `add_source_suffix()`. And it will become new standard of parser extensions after 2.0 (For more details, please read our docs http://www.sphinx-doc.org/en/master/extdev/parserapi.html).