### PR TITLE
Update package version to 0.5.0.dev

### DIFF
--- a/recommonmark/__init__.py
+++ b/recommonmark/__init__.py
@@ -1,6 +1,6 @@
 """Docutils CommonMark parser"""
 
-__version__ = '0.4.0'
+__version__ = '0.5.0.dev'
 
 
 def setup(app):


### PR DESCRIPTION
Clearly there have been many changes since 0.4.0. I propose the next release be 0.5.0. In the meantime, by adding a [development release separator](https://www.python.org/dev/peps/pep-0440/#development-release-separators) pip will more clearly indicate the package version for those installing via git.