### PR TITLE
rename `CommonMark` to `commonmark`

### DIFF
--- a/recommonmark/parser.py
+++ b/recommonmark/parser.py
@@ -6,7 +6,7 @@ from os.path import splitext
 from docutils import parsers, nodes
 from sphinx import addnodes
 
-from CommonMark import Parser
+from commonmark import Parser
 
 from warnings import warn
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -8,7 +8,7 @@ from docutils.utils import new_document
 from docutils.readers import Reader
 from docutils.core import publish_parts
 
-from CommonMark import Parser
+from commonmark import Parser
 from recommonmark.parser import CommonMarkParser
 
 


### PR DESCRIPTION
Fixes "ImportError: No module named CommonMark" as proposed in [rtfd/recommonmark#116](https://github.com/rtfd/recommonmark/issues/116#issue-358019182)