### PR TITLE
Add visit_html_block

### DIFF
--- a/recommonmark/parser.py
+++ b/recommonmark/parser.py
@@ -218,12 +218,18 @@ class CommonMarkParser(parsers.Parser):
         self.current_node.append(q)
         self.current_node = q
 
-    def visit_html_inline(self, mdnode):
+    def visit_html(self, mdnode):
         raw_node = nodes.raw(mdnode.literal,
                              mdnode.literal, format='html')
         if mdnode.sourcepos is not None:
             raw_node.line = mdnode.sourcepos[0][0]
         self.current_node.append(raw_node)
+
+    def visit_html_inline(self, mdnode):
+        self.visit_html(mdnode)
+
+    def visit_html_block(self, mdnode):
+        self.visit_html(mdnode)
 
     def visit_thematic_break(self, _):
         self.current_node.append(nodes.transition())

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -403,7 +403,7 @@ class TestParsing(unittest.TestCase):
             """
         )
 
-    def test_html(self):
+    def test_html_inline(self):
         self.assertParses(
             """
             Foo
@@ -419,6 +419,26 @@ class TestParsing(unittest.TestCase):
                 Blink
                 <raw format="html" xml:space="preserve">&lt;/blink&gt;</raw>
               </paragraph>
+            </document>
+            """
+        )
+
+    def test_html_block(self):
+        self.assertParses(
+            """
+            Foo
+
+            <div>
+                <blink>Blink</blink>
+            </div>
+            """,
+            """
+            <?xml version="1.0" ?>
+            <document source="&lt;string&gt;">
+              <paragraph>Foo</paragraph>
+              <raw format="html" xml:space="preserve">&lt;div&gt;
+                &lt;blink&gt;Blink&lt;/blink&gt;
+            &lt;/div&gt;</raw>
             </document>
             """
         )


### PR DESCRIPTION
Without this any html_block nodes processed by the parser are dropped.
`visit_html_block` uses the existing logic for `visit_html_inline`.

Added a test case to check html_blocks are parsed as expected.

Fixes: https://github.com/rtfd/recommonmark/issues/121