### PR TITLE
Code block custom language transformer

### DIFF
--- a/docs/auto_structify.md
+++ b/docs/auto_structify.md
@@ -31,6 +31,7 @@ All the features are by default enabled
 * __enable_inline_math__: whether enable [Inline Math](#inline-math)
 * __enable_eval_rst__: whether [Embed reStructuredText](#embed-restructuredtext) is enabled.
 * __url_resolver__: a function that maps a existing relative position in the document to a http link
+* __auto_code_block_transformers__: a dict of code block language to transformer function, see [Add custom code block language transformer](#add-custom-code-block-language-transformer)
 
 Auto Toc Tree
 -------------
@@ -228,6 +229,45 @@ The `<div style="clear: right;"></div>` line clears the sidebar for the next tit
 
 <div style="clear: right;"></div>
 
+### Add custom code block language transformer
+For some use cases it may be desirable to implement
+a custom transformer. Users of the Atom editor often use the
+[Markdown Preview Enhanced](https://github.com/shd101wyy/markdown-preview-enhanced)
+extention which renders a live preview of the markdown document. This extention
+embeds e.g. plantuml diagrams in this form:
+
+````rst
+```plantuml {align=center}
+@startuml
+Alice -> Bob
+@enduml
+```
+````
+
+To use this form in sphinx via recommonmark you first have
+to install sphinxcontrib-plantuml (`pip install sphinxcontrib-plantuml`) and
+enable it in sphinx conf.py via `extensions.append('sphinxcontrib.plantuml')`.
+
+At least implement and register a custom plantuml lanauge transformer function:
+
+```python
+# at the end of conf.py
+def transform_atom_markdown_plantuml(autostructify, node):
+    # for details see tests/sphinx_code_block_custom_language_transformer
+    pass
+
+def setup(app):
+    app.add_config_value(
+        'recommonmark_config',
+        {
+            'auto_code_block_transformers': {
+                'plantuml': transform_atom_markdown_plantuml
+            },
+        },
+        True
+    )
+    app.add_transform(AutoStructify)
+```
 
 Inline Math
 -----------

--- a/recommonmark/transform.py
+++ b/recommonmark/transform.py
@@ -1,5 +1,6 @@
 """Implement some common transforms on parsed AST."""
 
+import copy
 import os
 import re
 
@@ -41,11 +42,10 @@ class AutoStructify(transforms.Transform):
     def __init__(self, *args, **kwargs):
         transforms.Transform.__init__(self, *args, **kwargs)
         self.reporter = self.document.reporter
-        self.config = self.default_config.copy()
-        self.config['auto_code_block_transformers'] = \
-            dict(self.config['auto_code_block_transformers'])
+        self.config = copy.deepcopy(self.default_config)
         try:
-            new_cfg = self.document.settings.env.config.recommonmark_config
+            new_cfg = copy.deepcopy(
+                self.document.settings.env.config.recommonmark_config)
             custom_transformers = new_cfg.pop(
                 'auto_code_block_transformers', {})
             self.config.update(new_cfg)

--- a/tests/sphinx_code_block_custom_language_transformer/conf.py
+++ b/tests/sphinx_code_block_custom_language_transformer/conf.py
@@ -1,0 +1,61 @@
+
+# -*- coding: utf-8 -*-
+
+from recommonmark.parser import CommonMarkParser
+from recommonmark.transform import AutoStructify
+
+templates_path = ['_templates']
+source_suffix = '.md'
+source_parsers = { '.md': CommonMarkParser }
+master_doc = 'index'
+project = u'sphinxproj'
+copyright = u'2015, rtfd'
+author = u'rtfd'
+version = '0.1'
+release = '0.1'
+highlight_language = 'python'
+language = None
+exclude_patterns = ['_build']
+pygments_style = 'sphinx'
+todo_include_todos = False
+html_theme = 'alabaster'
+html_static_path = ['_static']
+htmlhelp_basename = 'sphinxproj'
+
+from docutils.parsers.rst import Parser
+from docutils.utils import new_document
+def transform_atom_markdown_plantuml(autostructify, node):
+    params = node['language'].strip().split()
+    language = params.pop(0)
+    directives = []
+    directives_string = u""
+    for param in params:
+        key, value = param.replace('{', '').replace('}', '').split('=')
+        key = key.strip()
+        value = value.strip()
+        directives.append(u"   :%s: %s" % (key, value))
+
+    if len(directives) > 0:
+        directives_string = u"\n".join(directives) + u"\n"
+
+    content = u"\n".join([u'   ' + l for l in node.rawsource.split('\n')])
+    parser = Parser()
+    new_doc = new_document(None, autostructify.document.settings)
+    # if sphinxcontrib-plantuml is installed:
+    # newsource = u'.. note::\n' + directives_string + u'   \n' + content
+    newsource = u'.. note::\n' + directives_string + u'   \n' + content
+    parser.parse(newsource, new_doc)
+    return new_doc.children[:]
+
+
+def setup(app):
+    app.add_config_value(
+        'recommonmark_config',
+        {
+            'auto_code_block_transformers': {
+                'plantuml': transform_atom_markdown_plantuml
+            },
+        },
+        True
+    )
+    app.add_transform(AutoStructify)

--- a/tests/sphinx_code_block_custom_language_transformer/index.md
+++ b/tests/sphinx_code_block_custom_language_transformer/index.md
@@ -1,0 +1,11 @@
+Header
+======
+
+A paragraph
+```plantuml
+@startuml
+Alice -> Bob
+@enduml
+```
+Another paragraph
+

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -177,9 +177,16 @@ class GenericTests(SphinxIntegrationTests):
 
 class CodeBlockTests(unittest.TestCase):
 
-    def test_integration(self):
+    def test_integration_code_block(self):
         with sphinx_built_file('sphinx_code_block', '_build/text/index.html') as output:
             self.assertIn('<div class="highlight">', output)
+
+    def test_integration_sphinx_code_block_custom_language_transformer(self):
+        with sphinx_built_file(
+                'sphinx_code_block_custom_language_transformer',
+                '_build/text/index.html') as output:
+            self.assertIn(
+                '&#64;startuml\nAlice -&gt; Bob\n&#64;enduml', output)
 
 
 class IndentedCodeTests(unittest.TestCase):

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,0 +1,57 @@
+from recommonmark.transform import AutoStructify, auto_code_block_eval_rst
+from docutils.utils import new_document
+import unittest
+
+
+class DummyConfig(object):
+    def __init__(self, config):
+        if config is None:
+            config = {}
+        self.recommonmark_config = config
+
+
+class DummyEnv(object):
+
+    def __init__(self, config):
+        self.config = config
+
+
+class AutoStructifyTestCase(unittest.TestCase):
+
+    def _make_one(self, recommonmark_config=None):
+        document = new_document('test data')
+        config = DummyConfig(recommonmark_config)
+        document.settings.env = DummyEnv(config)
+        transformer = AutoStructify(document)
+        return transformer
+
+    def test_init_uses_unmodified_default_config(self):
+        transformer = self._make_one()
+        assert transformer.config == transformer.default_config
+
+    def test_init_overrides_default_config(self):
+        transformer = self._make_one({'enable_auto_toc_tree': False})
+        assert transformer.config != transformer.default_config
+        assert transformer.config['enable_auto_toc_tree'] == False
+
+    def test_init_extends_auto_code_block_transformers(self):
+        transformers = {'plantuml': lambda x,y: x}
+        transformer = self._make_one(
+            {'auto_code_block_transformers': transformers})
+        langs = list(
+            transformer.config['auto_code_block_transformers'].keys())
+        langs.sort()
+        assert langs == ['eval_rst', 'math', 'plantuml']
+
+    def test_init_overrides_default_auto_code_block_transformer(self):
+        def dummy():
+            pass
+        transformer = self._make_one(
+            {'auto_code_block_transformers': {'math': dummy}})
+
+        should = {
+            'math': dummy,
+            'eval_rst': auto_code_block_eval_rst}
+
+        assert transformer.config['auto_code_block_transformers'] == should
+


### PR DESCRIPTION
Hi,

in some projects we document our code with plantuml diagrams embedded in markdown. To assist the creation of theses diagrams we use an atom editor extension which does live preview of plantuml.

To extend our workflow - the whole documentation is done with sphinx - we would like to have an extension mechanism in recommonmark to hook in a custom code block language transformer.

This pull request shows an implementation we are currently using in our fork of recommonmark. Maybe this code could be merged into upstream.

Best regards,
Martin
