### PR TITLE
Bump dependency on commonmark to >= 0.8.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'License :: OSI Approved :: MIT License',
     ],
     install_requires=[
-        'commonmark>=0.7.3',
+        'commonmark>=0.8.1',
         'docutils>=0.11',
         'sphinx>=1.3.1',
     ],


### PR DESCRIPTION
In #118, there was a change made to rename all commonmark imports from `commonmark` to `CommonMark` due to a breaking change to the package name in that dependency in version 0.8.1. However, the dependency on `commonmark` wasn't updated, which means that people pulling in commonmark >= 0.7.3 and < 0.8.1 are experiencing issues while using recommonmark. This updates the versioned dependency accordingly to resolve this issue.