### PR TITLE
Use image description text as "alt", drop title

### DIFF
--- a/recommonmark/parser.py
+++ b/recommonmark/parser.py
@@ -178,8 +178,9 @@ class CommonMarkParser(parsers.Parser):
         img_node = nodes.image()
         img_node['uri'] = mdnode.destination
 
-        if mdnode.title:
-            img_node['alt'] = mdnode.title
+        if mdnode.first_child and mdnode.first_child.literal:
+            img_node['alt'] = mdnode.first_child.literal
+            mdnode.first_child.literal = ''
 
         self.current_node.append(img_node)
         self.current_node = img_node

--- a/recommonmark/parser.py
+++ b/recommonmark/parser.py
@@ -179,8 +179,14 @@ class CommonMarkParser(parsers.Parser):
         img_node['uri'] = mdnode.destination
 
         if mdnode.first_child and mdnode.first_child.literal:
-            img_node['alt'] = mdnode.first_child.literal
+            content = [mdnode.first_child.literal]
+            n = mdnode.first_child
             mdnode.first_child.literal = ''
+            mdnode.first_child = mdnode.last_child = None
+            while getattr(n, 'nxt'):
+                n.nxt, n = None, n.nxt
+                content.append(n.literal)
+            img_node['alt'] = ''.join(content)
 
         self.current_node.append(img_node)
         self.current_node = img_node

--- a/tests/sphinx_generic/index.md
+++ b/tests/sphinx_generic/index.md
@@ -23,7 +23,7 @@ Foo
 
 Bar
 
-![foo](/image.png "Example")
+![foo "handle quotes"](/image.png "Example")
 
     #!/bin/sh
     python

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -232,7 +232,7 @@ class TestParsing(unittest.TestCase):
             <?xml version="1.0" ?>
             <document source="&lt;string&gt;">
               <paragraph>
-                <image alt="title" uri="/url">foo</image>
+                <image alt="foo" uri="/url"></image>
               </paragraph>
             </document>
             """

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -226,13 +226,13 @@ class TestParsing(unittest.TestCase):
     def test_image(self):
         self.assertParses(
             """
-            ![foo](/url "title")
+            ![foo "handle quotes"](/url "title")
             """,
             """
             <?xml version="1.0" ?>
             <document source="&lt;string&gt;">
               <paragraph>
-                <image alt="foo" uri="/url"></image>
+                <image alt="foo &quot;handle quotes&quot;" uri="/url"></image>
               </paragraph>
             </document>
             """

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -129,7 +129,7 @@ class GenericTests(SphinxIntegrationTests):
     def test_image(self):
         output = self.read_file('index.html')
         self.assertIn(
-            '<p><img alt="Example" src="image.png" />foo</p>',
+            '<p><img alt="foo" src="image.png" /></p>',
             output
         )
 

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -129,7 +129,7 @@ class GenericTests(SphinxIntegrationTests):
     def test_image(self):
         output = self.read_file('index.html')
         self.assertIn(
-            '<p><img alt="foo" src="image.png" /></p>',
+            '<p><img alt="foo &quot;handle quotes&quot;" src="image.png" /></p>',
             output
         )
 


### PR DESCRIPTION
The current [RecommonMark specification on images](https://spec.commonmark.org/0.28/#images) says that:

    ![foo](/url "title")

should render as

    <p><img src="/url" alt="foo" title="title" /></p>

which means that "foo" should be the `alt` attribute, and "title" should be the `title` attribute.

Currently, `recommonmark` will:

1. set the `alt` attribute to "title"
2. render "foo" as literal text following the image element.

Neither yields results in line with the RecommonMark standard, resulting in the following when transformed to HTML:

    <p><img src="/url" alt="title" />foo</p>

While it might be surprising that `alt` is set to "title", the more pressing issue is how the alt text becomes literal text within the paragraph, typically not rendering well.

This pull request instead makes `recommonmark`:

1. set the `alt` attribute to "foo"
2. drop "title" altogether since [the `title` attribute is not supported in Docutils](http://docutils.sourceforge.net/docs/ref/rst/directives.html#image).

1 coincides with the specification, and 2 is in my mind the least surprising solution within the capabilities of Docutils. The HTML will now be:

    <p><img src="/url" alt="foo" /></p>

only differing in the missing `title` attribute when compared to the specification.
