### PR TITLE
Updates to link handling

### DIFF
--- a/recommonmark/parser.py
+++ b/recommonmark/parser.py
@@ -130,49 +130,38 @@ class CommonMarkParser(parsers.Parser):
         self.current_node.append(n)
 
     def visit_link(self, mdnode):
-        ref_node = nodes.reference()
-        # Check destination is supported for cross-linking and remove extension
         destination = mdnode.destination
         _, ext = splitext(destination)
+        # Check destination is supported for cross-linking and remove extension
         # TODO check for other supported extensions, such as those specified in
         # the Sphinx conf.py file but how to access this information?
         # TODO this should probably only remove the extension for local paths,
         # i.e. not uri's starting with http or other external prefix.
         if ext.replace('.', '') in self.supported:
             destination = destination.replace(ext, '')
-        ref_node['refuri'] = destination
-        # TODO okay, so this is acutally not always the right line number, but
-        # these mdnodes won't have sourcepos on them for whatever reason. This
-        # is better than 0 though.
-        ref_node.line = self._get_line(mdnode)
-        if mdnode.title:
-            ref_node['title'] = mdnode.title
-        next_node = ref_node
 
         url_check = urlparse(destination)
         if not url_check.scheme and not url_check.fragment:
-            wrap_node = addnodes.pending_xref(
+            ref_node = addnodes.pending_xref(
                 reftarget=unquote(destination),
                 reftype='any',
                 refdomain=None,  # Added to enable cross-linking
                 refexplicit=True,
                 refwarn=True
             )
-            # TODO also not correct sourcepos
-            wrap_node.line = self._get_line(mdnode)
-            if mdnode.title:
-                wrap_node['title'] = mdnode.title
-            wrap_node.append(ref_node)
-            next_node = wrap_node
-
-        self.current_node.append(next_node)
-        self.current_node = ref_node
-
-    def depart_link(self, mdnode):
-        if isinstance(self.current_node.parent, addnodes.pending_xref):
-            self.current_node = self.current_node.parent.parent
         else:
-            self.current_node = self.current_node.parent
+            ref_node = nodes.reference()
+        ref_node['refuri'] = destination
+
+        # TODO okay, so this is acutally not always the right line number, but
+        # these mdnodes won't have sourcepos on them for whatever reason. This
+        # is better than 0 though.
+        ref_node.line = self._get_line(mdnode)
+        if mdnode.title:
+            ref_node['title'] = mdnode.title
+
+        self.current_node.append(ref_node)
+        self.current_node = ref_node
 
     def visit_image(self, mdnode):
         img_node = nodes.image()

--- a/recommonmark/parser.py
+++ b/recommonmark/parser.py
@@ -131,6 +131,13 @@ class CommonMarkParser(parsers.Parser):
 
     def visit_link(self, mdnode):
         destination = mdnode.destination
+        if not destination:
+            # If the destination of the link is empty, use the value of the string
+            # contained in the text to be rendered, if there is any.
+            for walker_node, _entering in mdnode.walker():
+                if walker_node.literal:
+                    destination = walker_node.literal
+                    break
         _, ext = splitext(destination)
         # Check destination is supported for cross-linking and remove extension
         # TODO check for other supported extensions, such as those specified in

--- a/recommonmark/transform.py
+++ b/recommonmark/transform.py
@@ -163,9 +163,7 @@ class AutoStructify(transforms.Transform):
             if len(par.children) != 1:
                 return None
             ref = par.children[0]
-            if isinstance(ref, addnodes.pending_xref):
-                ref = ref.children[0]
-            if not isinstance(ref, nodes.reference):
+            if not isinstance(ref, (addnodes.pending_xref, nodes.reference)):
                 return None
             title, uri, docpath = self.parse_ref(ref)
             if title is None or uri.startswith('#'):

--- a/tests/sphinx_generic/index.md
+++ b/tests/sphinx_generic/index.md
@@ -10,7 +10,9 @@ This is a [link](http://example.com "Example")
 
 This is a [ref link][example]
 
-This is a [relative link](/example)
+This is a [relative link](/index)
+
+This is another [relative link](/foo)
 
 This is a [pending ref](index)
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -183,9 +183,7 @@ class TestParsing(unittest.TestCase):
             <?xml version="1.0" ?>
             <document source="&lt;string&gt;">
               <paragraph>
-                <pending_xref refdomain="None" refexplicit="True" reftarget="/foo" reftype="any" refwarn="True">
-                  <reference refuri="/foo">link</reference>
-                </pending_xref>
+                <pending_xref refdomain="None" refexplicit="True" reftarget="/foo" reftype="any" refuri="/foo" refwarn="True">link</pending_xref>
               </paragraph>
             </document>
             """
@@ -198,9 +196,7 @@ class TestParsing(unittest.TestCase):
             <?xml version="1.0" ?>
             <document source="&lt;string&gt;">
               <paragraph>
-                <pending_xref refdomain="None" refexplicit="True" reftarget="foo" reftype="any" refwarn="True">
-                  <reference refuri="foo">link</reference>
-                </pending_xref>
+                <pending_xref refdomain="None" refexplicit="True" reftarget="foo" reftype="any" refuri="foo" refwarn="True">link</pending_xref>
               </paragraph>
             </document>
             """
@@ -214,9 +210,7 @@ class TestParsing(unittest.TestCase):
             <document source="&lt;string&gt;">
               <paragraph>
                 <strong>
-                  <pending_xref refdomain="None" refexplicit="True" reftarget="foo" reftype="any" refwarn="True">
-                    <reference refuri="foo">link</reference>
-                  </pending_xref>
+                  <pending_xref refdomain="None" refexplicit="True" reftarget="foo" reftype="any" refuri="foo" refwarn="True">link</pending_xref>
                 </strong>
               </paragraph>
             </document>
@@ -291,23 +285,17 @@ class TestParsing(unittest.TestCase):
               <bullet_list>
                 <list_item>
                   <paragraph>
-                    <pending_xref refdomain="None" refexplicit="True" reftarget="/1" reftype="any" refwarn="True">
-                      <reference refuri="/1">List item 1</reference>
-                    </pending_xref>
+                    <pending_xref refdomain="None" refexplicit="True" reftarget="/1" reftype="any" refuri="/1" refwarn="True">List item 1</pending_xref>
                   </paragraph>
                 </list_item>
                 <list_item>
                   <paragraph>
-                    <pending_xref refdomain="None" refexplicit="True" reftarget="/2" reftype="any" refwarn="True">
-                      <reference refuri="/2">List item 2</reference>
-                    </pending_xref>
+                    <pending_xref refdomain="None" refexplicit="True" reftarget="/2" reftype="any" refuri="/2" refwarn="True">List item 2</pending_xref>
                   </paragraph>
                 </list_item>
                 <list_item>
                   <paragraph>
-                    <pending_xref refdomain="None" refexplicit="True" reftarget="/3" reftype="any" refwarn="True">
-                      <reference refuri="/3">List item 3</reference>
-                    </pending_xref>
+                    <pending_xref refdomain="None" refexplicit="True" reftarget="/3" reftype="any" refuri="/3" refwarn="True">List item 3</pending_xref>
                   </paragraph>
                 </list_item>
               </bullet_list>

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -114,8 +114,14 @@ class GenericTests(SphinxIntegrationTests):
         )
         self.assertIn(
             ('This is a '
-             '<a class="reference external" '
-             'href="/example">relative link</a>'),
+             '<a class="reference internal" '
+             'href="#"><span class="doc">relative link</span></a>'),
+            output
+        )
+        self.assertIn(
+            ('This is another '
+             '<a class="reference internal" '
+             'href="foo.html"><span class="doc">relative link</span></a>'),
             output
         )
         self.assertIn(


### PR DESCRIPTION
- Fix the handling of pending_xref objects so that they are handled by sphinx correctly.
- Allow the destination of a link to be determined by its string content.