### PR TITLE
Added method depart_document called in sphinx documentation. Already t…

### DIFF
--- a/recommonmark/parser.py
+++ b/recommonmark/parser.py
@@ -241,6 +241,9 @@ class CommonMarkParser(parsers.Parser):
     def visit_thematic_break(self, _):
         self.current_node.append(nodes.transition())
 
+    def depart_document(self, _):
+        self._level_to_elem = {}
+
     # Section handling
     def setup_sections(self):
         self._level_to_elem = {0: self.document}

--- a/recommonmark/parser.py
+++ b/recommonmark/parser.py
@@ -52,6 +52,10 @@ class CommonMarkParser(parsers.Parser):
     def default_visit(self, mdnode):
         pass
 
+    @staticmethod
+    def skipped_node_message(node_type):
+        return "Container node skipped: type={0}".format(node_type)
+
     def default_depart(self, mdnode):
         """Default node depart handler
 
@@ -62,7 +66,7 @@ class CommonMarkParser(parsers.Parser):
         if mdnode.is_container():
             fn_name = 'visit_{0}'.format(mdnode.t)
             if not hasattr(self, fn_name):
-                warn("Container node skipped: type={0}".format(mdnode.t))
+                warn(self.skipped_node_message(mdnode.t))
             else:
                 self.current_node = self.current_node.parent
 

--- a/tests/sphinx_node_warnings/conf.py
+++ b/tests/sphinx_node_warnings/conf.py
@@ -1,0 +1,22 @@
+
+# -*- coding: utf-8 -*-
+
+from recommonmark.parser import CommonMarkParser
+
+templates_path = ['_templates']
+source_suffix = ['.rst', '.md']
+source_parsers = { '.md': CommonMarkParser }
+master_doc = 'index'
+project = u'sphinxproj'
+copyright = u'2015, rtfd'
+author = u'rtfd'
+version = '0.1'
+release = '0.1'
+highlight_language = 'python'
+language = None
+exclude_patterns = ['_build']
+pygments_style = 'sphinx'
+todo_include_todos = False
+html_theme = 'alabaster'
+html_static_path = ['_static']
+htmlhelp_basename = 'sphinxproj'

--- a/tests/sphinx_node_warnings/index.rst
+++ b/tests/sphinx_node_warnings/index.rst
@@ -1,0 +1,5 @@
+Title
+=====
+
+.. toctree::
+   mdfile

--- a/tests/sphinx_node_warnings/mdfile.md
+++ b/tests/sphinx_node_warnings/mdfile.md
@@ -1,0 +1,3 @@
+## Heading
+
+This is a paragraph


### PR DESCRIPTION
…ested in CustomExtensionTests::test_integration

I have added "depart_method" in the parser file. A minor change to avoid the annoying warning when leaving the document found building sphinx documentation.