### PR TITLE
Fix CustomExtensionTests.test_integration failure with docutils 0.16

### DIFF
--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -5,7 +5,6 @@ import shutil
 import unittest
 from contextlib import contextmanager
 
-import docutils
 from sphinx.application import Sphinx
 
 
@@ -218,16 +217,11 @@ class CustomExtensionTests(SphinxIntegrationTests):
         self.assertIn('<th class="head">data</th>', output)
         self.assertIn('</table>', output)
 
-        if docutils.__version_info__ >= (0, 16):
-            additional_class = ''
-        else:
-            additional_class = ' first'
+        self.assertIn('<div class="contents topic" id="contents">\n', output)
         self.assertIn(
-            ('<div class="contents topic" id="contents">\n'
-             '<p class="topic-title{}">Contents</p>\n'
-             '<ul class="simple">\n'
+            ('<ul class="simple">\n'
              '<li><a class="reference internal" href="#header" id="id1">Header</a><ul>\n'
              '<li><a class="reference internal" href="#header-2" id="id2">Header 2</a></li>\n'
-             '</ul>\n</li>\n</ul>'.format(additional_class)),
+             '</ul>\n</li>\n</ul>'),
             output
             )

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -5,6 +5,7 @@ import shutil
 import unittest
 from contextlib import contextmanager
 
+import docutils
 from sphinx.application import Sphinx
 
 
@@ -217,12 +218,16 @@ class CustomExtensionTests(SphinxIntegrationTests):
         self.assertIn('<th class="head">data</th>', output)
         self.assertIn('</table>', output)
 
+        if docutils.__version_info__ >= (0, 16):
+            additional_class = ''
+        else:
+            additional_class = ' first'
         self.assertIn(
             ('<div class="contents topic" id="contents">\n'
-             '<p class="topic-title first">Contents</p>\n'
+             '<p class="topic-title{}">Contents</p>\n'
              '<ul class="simple">\n'
              '<li><a class="reference internal" href="#header" id="id1">Header</a><ul>\n'
              '<li><a class="reference internal" href="#header-2" id="id2">Header 2</a></li>\n'
-             '</ul>\n</li>\n</ul>'),
+             '</ul>\n</li>\n</ul>'.format(additional_class)),
             output
             )


### PR DESCRIPTION
All automated tests on Travis for PRs from January has failed because docutils 0.16 (2020-01-12) contains a following commit.

    HTML fixes and updates.

    Remove dead code.
    Remove unused class value "first" for topic-title.
    Fix/update CSS stylesheets for html5 writer.

https://repo.or.cz/docutils.git/commit/e094ffdca98f49dab492ec4f8de5d2be7ec8f23d

This commit is a workaround to that change.

Could you please find and check this PR?  If this solution is not good, please suggest me so.  I'd like to make another solution.