### PR TITLE
Add settings for testing with Python 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
   - 2.7
   - 3.5
   - 3.6
+  - 3.7
+  - 3.8
 sudo: false
 install:
   - pip install tox-travis

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,35,36}-sphinx{16,17,18},
+    py{27,35,36,37,38}-sphinx{16,17,18},
     # Workaround https://github.com/tox-dev/tox/issues/706
     lint-sphinx18
     docs-sphinx18
@@ -9,6 +9,8 @@ envlist =
 2.7 = py27-sphinx{16,17,18}, docs-sphinx16, lint-sphinx16
 3.5 = py35-sphinx{16,17,18}
 3.6 = py36-sphinx{16,17,18}
+3.7 = py37-sphinx{16,17,18}
+3.8 = py38-sphinx{16,17,18}
 
 [testenv]
 setenv =


### PR DESCRIPTION
Hello,

This PR adds settings for testing with Python 3.7 and 3.8 as those versions were released on 2018-06-27 and 2019-10-14, respectively.
Although EoL of Python 2.7 was 2020-01-01, since both commonmark and docutils still support 2.7, this PR leaves behind 2.7 in the setting.

It would be happy if you find this PR.

Many thanks,