### PR TITLE
Allow custom processing of ref nodes

### DIFF
--- a/recommonmark/parser.py
+++ b/recommonmark/parser.py
@@ -210,7 +210,7 @@ class CommonMarkParser(parsers.Parser):
         return wrap_node
 
     def depart_link(self, mdnode):
-        if isinstance(self.current_node.parent, addnodes.pending_xref):
+        if addnodes is not None and isinstance(self.current_node.parent, addnodes.pending_xref):
             self.current_node = self.current_node.parent.parent
         else:
             self.current_node = self.current_node.parent

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,10 @@ setup(
     install_requires=[
         'commonmark>=0.8.1',
         'docutils>=0.11',
-        'sphinx>=1.3.1',
     ],
+    extras_require={
+        'sphinx': ['sphinx>=1.3.1'],
+    },
     entry_points={'console_scripts': [
         'cm2html = recommonmark.scripts:cm2html',
         'cm2latex = recommonmark.scripts:cm2latex',


### PR DESCRIPTION
This PR makes Sphinx an optional dependency and moves ref_node-wrapping logic to a separate method. This would allow non-Sphinx users to override the behaviour for internal links by subclassing CommonMarkParser. The most trivial example would be:

```py
class SimpleCommonMarkParser(CommonMarkParser):
    def wrap_ref_node(self, ref_node):
        return ref_node
```

which would be useful in cm2html and other scripts which don't need to do complex stuff with refs.

Related: #202, #205.